### PR TITLE
Added UnityWasmScriptingSettings

### DIFF
--- a/Assets/Resources.meta
+++ b/Assets/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 24ef4ddb5d75a334d8c24571f8e0e117
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/UnityWasmScriptingSettings.asset
+++ b/Assets/Resources/UnityWasmScriptingSettings.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 17ef07162f644dd5817bd5f83b779da3, type: 3}
+  m_Name: UnityWasmScriptingSettings
+  m_EditorClassIdentifier: 
+  projectRootOverride: 
+  wasmModulePathOverride: 

--- a/Assets/Resources/UnityWasmScriptingSettings.asset.meta
+++ b/Assets/Resources/UnityWasmScriptingSettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d798b7247fb0bd84989a9a235db55151
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripting/Editor.meta
+++ b/Assets/Scripting/Editor.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 72b79836d682420e9d4209a031768849
+timeCreated: 1745549945

--- a/Assets/Scripting/Editor/GUI.meta
+++ b/Assets/Scripting/Editor/GUI.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ce2e3a9341f844e28366248a620f8066
+timeCreated: 1745550828

--- a/Assets/Scripting/Editor/GUI/WasmBehaviourEditor.cs
+++ b/Assets/Scripting/Editor/GUI/WasmBehaviourEditor.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+namespace WasmScripting {
+    [CustomEditor(typeof(WasmBehaviour))]
+    public class WasmBehaviourInspector : Editor {
+        private const string BuiltModulePath = @"bin\Release\net9.0\wasi-wasm\publish\WasmModule.wasm";
+		
+        public override void OnInspectorGUI() 
+        {
+            base.OnInspectorGUI();
+            
+            if (!GUILayout.Button("Build Wasm Module")) 
+                return;
+            
+            WasmVM vm = ((Component)target).GetComponentInParent<WasmVM>(true);
+            WasmBehaviour[] behaviours = vm.GetComponentsInChildren<WasmBehaviour>(true);
+				    
+            string ProjectRoot = UnityWasmScriptingSettingsManager.GetProjectRoot();
+            string WasmProjectPath = UnityWasmScriptingSettingsManager.GetWasmModulePath();
+                
+            Directory.Delete(Path.Combine(WasmProjectPath, "Temp"), true);
+            Directory.CreateDirectory(Path.Combine(WasmProjectPath, "Temp"));
+
+            HashSet<string> scriptNames = new();
+            foreach (var behaviour in behaviours) {
+                MonoScript script = behaviour.script;
+                behaviour.BehaviourName = script.GetClass().FullName;
+					    
+                if (scriptNames.Add(script.name)) {
+                    string srcPath = AssetDatabase.GetAssetPath(script);
+                    string dstPath = Path.Combine(WasmProjectPath, "Temp", $"{behaviour.BehaviourName}.cs");
+                    File.Copy(srcPath, dstPath);
+                }
+            }
+
+            Process buildCmd = CreateCmdProcess(WasmProjectPath, $"/c cd \"{WasmProjectPath}\" && build.bat");
+
+            buildCmd.Start();
+            buildCmd.WaitForExit();
+
+            File.Copy(Path.Combine(WasmProjectPath, BuiltModulePath), Path.Combine(ProjectRoot, "WasmModule.wasm"), true);
+				    
+            const string modulePath = "Assets/WasmModule.wasm";
+            AssetDatabase.ImportAsset(modulePath);
+            vm.moduleAsset = AssetDatabase.LoadAssetAtPath<WasmModuleAsset>(modulePath);
+        }
+
+        private static Process CreateCmdProcess(string workingDirectory, string arguments)
+        {
+            bool hideWindow = UnityWasmScriptingSettingsManager.GetHideCommandPrompt();
+            return new Process 
+            {
+                StartInfo = new ProcessStartInfo 
+                {
+                    FileName = @"C:\Windows\System32\cmd.exe",
+                    Arguments = arguments,
+                    UseShellExecute = !hideWindow,
+                    RedirectStandardOutput = hideWindow,
+                    CreateNoWindow = hideWindow,
+                    WorkingDirectory = workingDirectory
+                }
+            };
+        }
+    }
+}

--- a/Assets/Scripting/Editor/GUI/WasmBehaviourEditor.cs.meta
+++ b/Assets/Scripting/Editor/GUI/WasmBehaviourEditor.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b729e694711846a28b1a50f218dcb78f
+timeCreated: 1745550840

--- a/Assets/Scripting/Editor/Settings.meta
+++ b/Assets/Scripting/Editor/Settings.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2143a6d3e8dc4a13954d1aa5e66ee79a
+timeCreated: 1745550114

--- a/Assets/Scripting/Editor/Settings/UnityWasmScriptingSettings.cs
+++ b/Assets/Scripting/Editor/Settings/UnityWasmScriptingSettings.cs
@@ -1,0 +1,11 @@
+﻿using UnityEngine;
+
+/// <summary>
+/// Settings store object for UnityWasmScripting.
+/// </summary>
+public class UnityWasmScriptingSettings : ScriptableObject
+{
+    public string projectRootOverride = "";
+    public string wasmModulePathOverride = "";
+    public bool hideCommandPrompt;
+}

--- a/Assets/Scripting/Editor/Settings/UnityWasmScriptingSettings.cs.meta
+++ b/Assets/Scripting/Editor/Settings/UnityWasmScriptingSettings.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 17ef07162f644dd5817bd5f83b779da3
+timeCreated: 1745549971

--- a/Assets/Scripting/Editor/Settings/UnityWasmScriptingSettingsManager.cs
+++ b/Assets/Scripting/Editor/Settings/UnityWasmScriptingSettingsManager.cs
@@ -1,0 +1,52 @@
+﻿using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+/// <summary>
+/// Manages the settings for UnityWasmScripting.
+/// </summary>
+public static class UnityWasmScriptingSettingsManager
+{
+    private const string ProjectName = "UnityWasmScripting";
+    private const string DefaultWasmModulePath = ".WasmModule";
+    
+    private static UnityWasmScriptingSettings s_Instance;
+    private static readonly string k_SettingsPath = $"Assets/Resources/{ProjectName}Settings.asset";
+
+    #region Settings Access
+    
+    public static UnityWasmScriptingSettings GetOrCreateSettings()
+    {
+        if (s_Instance != null)
+            return s_Instance;
+            
+        s_Instance = AssetDatabase.LoadAssetAtPath<UnityWasmScriptingSettings>(k_SettingsPath);
+        
+        if (s_Instance == null)
+        {
+            string directory = Path.GetDirectoryName(k_SettingsPath);
+            if (!Directory.Exists(directory))
+                Directory.CreateDirectory(directory ?? throw new DirectoryNotFoundException());
+            
+            s_Instance = ScriptableObject.CreateInstance<UnityWasmScriptingSettings>();
+            AssetDatabase.CreateAsset(s_Instance, k_SettingsPath);
+            AssetDatabase.SaveAssets();
+        }
+        
+        return s_Instance;
+    }
+    
+    public static string GetProjectRoot() => 
+        string.IsNullOrEmpty(GetOrCreateSettings()?.projectRootOverride) 
+            ? Application.dataPath : GetOrCreateSettings().projectRootOverride;
+        
+    public static string GetWasmModulePath() => 
+        string.IsNullOrEmpty(GetOrCreateSettings()?.wasmModulePathOverride) 
+            ? Path.Combine(GetProjectRoot(), DefaultWasmModulePath) 
+            : GetOrCreateSettings().wasmModulePathOverride;
+    
+    public static bool GetHideCommandPrompt() => 
+        GetOrCreateSettings()?.hideCommandPrompt ?? false;
+    
+    #endregion Settings Access
+}

--- a/Assets/Scripting/Editor/Settings/UnityWasmScriptingSettingsManager.cs.meta
+++ b/Assets/Scripting/Editor/Settings/UnityWasmScriptingSettingsManager.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: fdb1d8a8045c4bdbb1024e842dae6e49
+timeCreated: 1745550148

--- a/Assets/Scripting/Editor/Settings/UnityWasmScriptingSettingsProvider.cs
+++ b/Assets/Scripting/Editor/Settings/UnityWasmScriptingSettingsProvider.cs
@@ -1,0 +1,71 @@
+﻿using UnityEditor;
+
+/// <summary>
+/// Creates the settings provider so the user can modify the settings via the Unity Project Settings window.
+/// </summary>
+public class UnityWasmScriptingSettingsProvider : SettingsProvider
+{
+    private const string ProjectName = "UnityWasmScripting";
+    private const string DefaultProjectRoot = "Assets";
+    private const string DefaultWasmModulePath = ".WasmModule";
+    
+    private SerializedObject m_Settings;
+
+    private UnityWasmScriptingSettingsProvider(string path, SettingsScope scope = SettingsScope.Project)
+        : base(path, scope) {}
+    
+    #region Settings Management
+    
+    private SerializedObject GetSerializedSettings() => m_Settings ??= new SerializedObject(UnityWasmScriptingSettingsManager.GetOrCreateSettings());
+    
+    #endregion Settings Management
+
+    #region GUI Methods
+    
+    public override void OnGUI(string searchContext)
+    {
+        SerializedObject settings = GetSerializedSettings();
+        
+        EditorGUILayout.Space();
+        EditorGUILayout.LabelField($"{ProjectName} Settings", EditorStyles.boldLabel);
+        EditorGUILayout.Space();
+        
+        EditorGUILayout.LabelField("Default Paths:", EditorStyles.boldLabel);
+        EditorGUILayout.LabelField($"Project Root: {DefaultProjectRoot}");
+        EditorGUILayout.LabelField($"WASM Module Path: {DefaultProjectRoot}/{DefaultWasmModulePath}");
+        EditorGUILayout.Space();
+        
+        EditorGUILayout.LabelField("Path Overrides:", EditorStyles.boldLabel);
+        EditorGUI.BeginChangeCheck();
+        
+        SerializedProperty prop = settings.GetIterator();
+        if (prop.NextVisible(true))
+        {
+            do
+            {
+                if (prop.propertyPath == "m_Script") continue;
+                EditorGUILayout.PropertyField(prop, true);
+            }
+            while (prop.NextVisible(false));
+        }
+        
+        if (EditorGUI.EndChangeCheck()) settings.ApplyModifiedProperties();
+    }
+    
+    #endregion GUI Methods
+
+    #region Provider Registration
+    
+    [SettingsProvider]
+    public static SettingsProvider CreateSettingsProvider()
+    {
+        UnityWasmScriptingSettingsProvider provider = new($"Project/{ProjectName}")
+        {
+            keywords = GetSearchKeywordsFromSerializedObject(
+                new SerializedObject(UnityWasmScriptingSettingsManager.GetOrCreateSettings()))
+        };
+        return provider;
+    }
+    
+    #endregion Provider Registration
+}

--- a/Assets/Scripting/Editor/Settings/UnityWasmScriptingSettingsProvider.cs.meta
+++ b/Assets/Scripting/Editor/Settings/UnityWasmScriptingSettingsProvider.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3ac8fbc81260414294ecab02b4af591c
+timeCreated: 1745550131

--- a/Assets/Scripting/WasmBehaviour.cs
+++ b/Assets/Scripting/WasmBehaviour.cs
@@ -16,16 +16,18 @@ namespace WasmScripting {
 		public List<WasmVariable<string>> stringVariables;
 		public List<WasmVariable<Component>> componentVariables;
 		public List<WasmVariable<GameObject>> gameObjectVariables;
+
+		[HideInInspector] 
+		public string BehaviourName;
 		
-		public int InstanceId { get; private set; }
-		[NonSerialized] public string BehaviourName;
+		// Set by WasmVM
+		internal int InstanceId;
 		
 		private WasmVM _vm;
 
 		#region Unity Events
 		
 		private void Awake() {
-			InstanceId = GetInstanceID();
 			_vm = GetComponentInParent<WasmVM>();
 			if (_vm.Awaked) _vm.CallMethod(InstanceId, "Awake");
 		}

--- a/Assets/Scripting/WasmVM.cs
+++ b/Assets/Scripting/WasmVM.cs
@@ -34,6 +34,7 @@ namespace WasmScripting {
 			
 			foreach (WasmBehaviour behaviour in GetComponentsInChildren<WasmBehaviour>(true)) {
 				int id = behaviour.GetInstanceID();
+				behaviour.InstanceId = id;
 				CreateInstance(id, behaviour);
 			}
 


### PR DESCRIPTION
- Added UnityWasmScriptingSettings
  - Added hideCommandPrompt setting for debugging
  - Added optional overrides for .WasmModule & ProjectRoot directories
- Fixed .WasmModule & ProjectRoot directories being hardcoded
- Fixed WasmBehaviourGUI build module button not finding disabled WasmBehaviours in children
- Extracted WasmBehaviourEditor to `/Editor` folder